### PR TITLE
Add pytest test suite (128 tests) and GitHub Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,49 @@
+name: Run Tests
+
+# Run the test suite on every push to main and on every pull request
+# targeting main.  This ensures all new code is validated before merge.
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    name: pytest (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        # Installs runtime deps (automationhat is skipped on x86_64 due to the
+        # platform marker in pyproject.toml) plus the 'dev' group (pytest etc.)
+        run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest tests/ -v --tb=short --no-header
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: .pytest_cache/
+          retention-days: 7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,16 @@ dependencies = [
     "werkzeug==3.0.1",
     "pymysql==1.1.0",
     "python-dotenv==1.0.0",
-    "automationhat==1.0.0",
+    # automationhat only installs on Raspberry Pi (ARM64); skipped on CI/dev machines
+    "automationhat==1.0.0 ; platform_machine == 'aarch64'",
     "apscheduler==3.10.4",
 ]
 
 [tool.uv]
 package = false
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-cov>=5.0.0",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,3 +137,13 @@ def admin_client(app, mock_db):
             sess["_user_id"] = "admin"
             sess["_fresh"] = True
         yield c
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle hook
+# ---------------------------------------------------------------------------
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Stop the module-level patcher when the test session ends."""
+    _init_patcher.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,139 @@
+"""
+Pytest configuration and shared fixtures for the garage door app tests.
+
+Strategy
+--------
+We set the three required env-vars so DatabaseManager.__init__ doesn't raise
+ValueError, then patch only _ensure_database_setup so no real MySQL
+connection is attempted during app startup.
+
+The real DatabaseManager class remains untouched, which means
+test_database_manager.py can instantiate it via __new__ and inject mock
+connections freely.
+
+For route tests, the mock_db fixture temporarily replaces app.db_manager
+with a fresh MagicMock (restored automatically after each test).
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the project root is importable regardless of how pytest is invoked.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# ---------------------------------------------------------------------------
+# Set minimal env-vars so DatabaseManager._get_connection_params() passes its
+# validation check.  These values are never used for a real connection because
+# _ensure_database_setup is patched out below.
+# ---------------------------------------------------------------------------
+os.environ.setdefault("DB_USER", "test_user")
+os.environ.setdefault("DB_PASSWORD", "test_password")
+os.environ.setdefault("DB_NAME", "test_db")
+
+# ---------------------------------------------------------------------------
+# Patch _ensure_database_setup before importing the app.  This prevents the
+# constructor from attempting a real MySQL connection while still leaving the
+# DatabaseManager class itself intact (so __new__ works in DB unit tests).
+# ---------------------------------------------------------------------------
+_init_patcher = patch("database.DatabaseManager._ensure_database_setup")
+_init_patcher.start()
+
+from app import app as _flask_app  # noqa: E402
+import app as _app_module  # noqa: E402
+
+_flask_app.config["TESTING"] = True
+_flask_app.config["SECRET_KEY"] = "test-secret-key-for-testing"
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def app():
+    """Flask application configured for testing."""
+    return _flask_app
+
+
+# ---------------------------------------------------------------------------
+# Function-scoped fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(app):
+    """Unauthenticated test client."""
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture
+def mock_db():
+    """
+    Replace app.db_manager with a fresh MagicMock for the duration of
+    one test, then restore the original.
+
+    Route tests configure return values on this mock; the real
+    DatabaseManager instance is never called during these tests.
+    """
+    original = _app_module.db_manager
+    mock_instance = MagicMock()
+    _app_module.db_manager = mock_instance
+    yield mock_instance
+    _app_module.db_manager = original
+
+
+@pytest.fixture
+def auth_client(app, mock_db):
+    """Test client logged in as a regular (non-admin) user."""
+    from user_roles import UserRole
+
+    mock_db.get_user_by_username.return_value = {
+        "id": 1,
+        "username": "testuser",
+        "role": UserRole.REGULAR.value,
+        "is_active": True,
+        "first_name": "Test",
+        "last_name": "User",
+        "email": "test@example.com",
+        "phone": None,
+        "sms_notifications_enabled": False,
+        "api_key_hash": None,
+        "password_hash": "hashed",
+    }
+
+    with app.test_client() as c:
+        with c.session_transaction() as sess:
+            sess["_user_id"] = "testuser"
+            sess["_fresh"] = True
+        yield c
+
+
+@pytest.fixture
+def admin_client(app, mock_db):
+    """Test client logged in as an admin user."""
+    from user_roles import UserRole
+
+    mock_db.get_user_by_username.return_value = {
+        "id": 2,
+        "username": "admin",
+        "role": UserRole.ADMIN.value,
+        "is_active": True,
+        "first_name": "Admin",
+        "last_name": "User",
+        "email": "admin@example.com",
+        "phone": None,
+        "sms_notifications_enabled": False,
+        "api_key_hash": None,
+        "password_hash": "hashed",
+    }
+
+    with app.test_client() as c:
+        with c.session_transaction() as sess:
+            sess["_user_id"] = "admin"
+            sess["_fresh"] = True
+        yield c

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -1,0 +1,405 @@
+"""
+Integration tests for Flask HTTP routes (app.py).
+
+Uses the test client fixtures from conftest.py; no real database or hardware.
+"""
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+from user_roles import UserRole
+
+
+# ---------------------------------------------------------------------------
+# Public / unauthenticated routes
+# ---------------------------------------------------------------------------
+
+
+class TestPublicRoutes:
+    """Routes that should be accessible without logging in."""
+
+    def test_login_page_get(self, client):
+        response = client.get("/login")
+        assert response.status_code == 200
+
+    def test_login_page_contains_form(self, client):
+        response = client.get("/login")
+        assert b"username" in response.data.lower()
+
+    def test_privacy_policy_accessible(self, client):
+        response = client.get("/privacy-policy")
+        assert response.status_code == 200
+
+    def test_terms_accessible(self, client):
+        response = client.get("/terms-and-conditions")
+        assert response.status_code == 200
+
+    def test_home_redirects_to_login_when_unauthenticated(self, client):
+        response = client.get("/", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/login" in response.headers["Location"]
+
+
+# ---------------------------------------------------------------------------
+# Login / Logout
+# ---------------------------------------------------------------------------
+
+
+class TestLogin:
+    def test_valid_credentials_redirect_to_home(self, client, mock_db):
+        mock_db.verify_password.return_value = True
+        mock_db.get_user_by_username.return_value = {
+            "id": 1,
+            "username": "alice",
+            "role": UserRole.REGULAR.value,
+            "is_active": True,
+            "first_name": None,
+            "last_name": None,
+            "email": None,
+            "phone": None,
+            "sms_notifications_enabled": False,
+            "api_key_hash": None,
+            "password_hash": "hashed",
+        }
+        response = client.post(
+            "/login",
+            data={"username": "alice", "password": "secret"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert "/" in response.headers["Location"]
+
+    def test_invalid_credentials_stay_on_login(self, client, mock_db):
+        mock_db.verify_password.return_value = False
+        response = client.post(
+            "/login",
+            data={"username": "alice", "password": "wrong"},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"login" in response.data.lower()
+
+    def test_invalid_credentials_show_error_message(self, client, mock_db):
+        mock_db.verify_password.return_value = False
+        response = client.post(
+            "/login",
+            data={"username": "alice", "password": "wrong"},
+            follow_redirects=True,
+        )
+        # Flash message should appear
+        assert b"invalid" in response.data.lower()
+
+    def test_db_exception_during_login_shows_error(self, client, mock_db):
+        mock_db.verify_password.side_effect = Exception("DB down")
+        response = client.post(
+            "/login",
+            data={"username": "alice", "password": "pass"},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"error" in response.data.lower()
+
+
+class TestLogout:
+    def test_unauthenticated_logout_redirects_to_login(self, client):
+        response = client.get("/logout", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/login" in response.headers["Location"]
+
+    def test_authenticated_logout_redirects_to_login(self, auth_client):
+        response = auth_client.get("/logout", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/login" in response.headers["Location"]
+
+
+# ---------------------------------------------------------------------------
+# Home / Dashboard
+# ---------------------------------------------------------------------------
+
+
+class TestHome:
+    def test_authenticated_user_sees_dashboard(self, auth_client):
+        response = auth_client.get("/")
+        assert response.status_code == 200
+
+    def test_dashboard_contains_door_controls(self, auth_client):
+        response = auth_client.get("/")
+        # The dashboard template should mention door or garage
+        assert b"garage" in response.data.lower() or b"door" in response.data.lower()
+
+
+# ---------------------------------------------------------------------------
+# Profile
+# ---------------------------------------------------------------------------
+
+
+class TestProfile:
+    def test_unauthenticated_redirected(self, client):
+        response = client.get("/profile", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/login" in response.headers["Location"]
+
+    def test_authenticated_user_sees_profile(self, auth_client):
+        response = auth_client.get("/profile")
+        assert response.status_code == 200
+
+    def test_profile_post_updates_profile(self, auth_client, mock_db):
+        mock_db.update_user_profile.return_value = True
+        response = auth_client.post(
+            "/profile",
+            data={
+                "first_name": "Alice",
+                "last_name": "Smith",
+                "email": "alice@example.com",
+                "phone": "555-1234",
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert mock_db.update_user_profile.called
+
+    def test_profile_password_change_wrong_current_password(self, auth_client, mock_db):
+        mock_db.update_user_profile.return_value = True
+        mock_db.verify_password.return_value = False
+        response = auth_client.post(
+            "/profile",
+            data={
+                "first_name": "Alice",
+                "current_password": "wrong",
+                "new_password": "newpass",
+                "confirm_password": "newpass",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"incorrect" in response.data.lower()
+
+    def test_profile_password_change_mismatched_passwords(self, auth_client, mock_db):
+        mock_db.update_user_profile.return_value = True
+        response = auth_client.post(
+            "/profile",
+            data={
+                "current_password": "oldpass",
+                "new_password": "newpass1",
+                "confirm_password": "newpass2",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"do not match" in response.data.lower()
+
+    def test_profile_password_change_success(self, auth_client, mock_db):
+        mock_db.update_user_profile.return_value = True
+        mock_db.verify_password.return_value = True
+        mock_db.update_password.return_value = True
+        response = auth_client.post(
+            "/profile",
+            data={
+                "current_password": "oldpass",
+                "new_password": "newpass",
+                "confirm_password": "newpass",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert mock_db.update_password.called
+
+
+# ---------------------------------------------------------------------------
+# API Key Generation
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateApiKey:
+    def test_unauthenticated_redirected(self, client):
+        response = client.post("/generate_api_key", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/login" in response.headers["Location"]
+
+    def test_authenticated_generates_key_and_redirects(self, auth_client, mock_db):
+        import secrets
+        mock_db.generate_api_key.return_value = secrets.token_hex(32)
+        response = auth_client.post("/generate_api_key", follow_redirects=False)
+        assert response.status_code == 302
+        assert mock_db.generate_api_key.called
+
+    def test_api_key_generation_failure_shows_error(self, auth_client, mock_db):
+        mock_db.generate_api_key.return_value = None
+        response = auth_client.post("/generate_api_key", follow_redirects=True)
+        assert response.status_code == 200
+        assert b"failed" in response.data.lower()
+
+
+# ---------------------------------------------------------------------------
+# Door Control (run_script)
+# ---------------------------------------------------------------------------
+
+
+class TestRunScript:
+    def test_unauthenticated_redirected(self, client):
+        response = client.post("/run_script", follow_redirects=False)
+        assert response.status_code == 302
+
+    def test_authenticated_invokes_relay_script(self, auth_client):
+        mock_proc = MagicMock()
+        mock_proc.stdout = ""
+        mock_proc.stderr = ""
+        mock_proc.returncode = 0
+        with patch("subprocess.run", return_value=mock_proc):
+            response = auth_client.post("/run_script")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["success"] is True
+
+    def test_timeout_returns_failure(self, auth_client):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("python", 30)):
+            response = auth_client.post("/run_script")
+        data = response.get_json()
+        assert data["success"] is False
+        assert "timed out" in data["error"].lower()
+
+    def test_exception_returns_failure(self, auth_client):
+        with patch("subprocess.run", side_effect=OSError("File not found")):
+            response = auth_client.post("/run_script")
+        data = response.get_json()
+        assert data["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# Door Status Endpoint (web UI)
+# ---------------------------------------------------------------------------
+
+
+class TestDoorStatus:
+    def test_unauthenticated_redirected(self, client):
+        response = client.get("/door_status", follow_redirects=False)
+        assert response.status_code == 302
+
+    def test_returns_json_with_status(self, auth_client):
+        mock_proc = MagicMock()
+        mock_proc.stdout = "Door Closed\n"
+        mock_proc.stderr = ""
+        with patch("subprocess.run", return_value=mock_proc):
+            response = auth_client.get("/door_status")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "closed"
+
+
+# ---------------------------------------------------------------------------
+# Admin Routes
+# ---------------------------------------------------------------------------
+
+
+class TestAdminRoutes:
+    def test_admin_page_lists_users(self, admin_client, mock_db):
+        mock_db.get_all_users.return_value = [
+            {"id": 1, "username": "alice", "role": "regular"}
+        ]
+        response = admin_client.get("/admin")
+        assert response.status_code == 200
+
+    def test_create_user_post_success(self, admin_client, mock_db):
+        mock_db.create_user.return_value = True
+        response = admin_client.post(
+            "/admin/create_user",
+            data={
+                "username": "newuser",
+                "password": "pass123",
+                "confirm_password": "pass123",
+                "role": UserRole.REGULAR.value,
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert mock_db.create_user.called
+
+    def test_create_user_mismatched_passwords(self, admin_client, mock_db):
+        response = admin_client.post(
+            "/admin/create_user",
+            data={
+                "username": "newuser",
+                "password": "pass1",
+                "confirm_password": "pass2",
+                "role": UserRole.REGULAR.value,
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"do not match" in response.data.lower()
+        assert not mock_db.create_user.called
+
+    def test_create_user_missing_fields(self, admin_client, mock_db):
+        response = admin_client.post(
+            "/admin/create_user",
+            data={"username": "", "password": "", "confirm_password": ""},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert not mock_db.create_user.called
+
+    def test_create_user_invalid_role(self, admin_client, mock_db):
+        response = admin_client.post(
+            "/admin/create_user",
+            data={
+                "username": "newuser",
+                "password": "pass",
+                "confirm_password": "pass",
+                "role": "superadmin",
+            },
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert not mock_db.create_user.called
+
+    def test_delete_user_success(self, admin_client, mock_db):
+        mock_db.delete_user.return_value = True
+        response = admin_client.post(
+            "/admin/delete_user/alice", follow_redirects=False
+        )
+        assert response.status_code == 302
+        mock_db.delete_user.assert_called_once_with("alice")
+
+    def test_cannot_delete_own_account(self, admin_client, mock_db):
+        """Admin cannot delete themselves via the UI."""
+        response = admin_client.post(
+            "/admin/delete_user/admin", follow_redirects=True
+        )
+        assert response.status_code == 200
+        assert b"cannot delete your own account" in response.data.lower()
+        assert not mock_db.delete_user.called
+
+    def test_change_password_success(self, admin_client, mock_db):
+        # admin_client already sets get_user_by_username to return the admin user;
+        # don't override it here or Flask-Login would load a non-admin and the
+        # admin_required decorator would redirect before the handler runs.
+        mock_db.update_user_password_by_admin.return_value = True
+        response = admin_client.post(
+            "/admin/change_password/alice",
+            data={"new_password": "newpass", "confirm_password": "newpass"},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        mock_db.update_user_password_by_admin.assert_called_once_with("alice", "newpass")
+
+    def test_change_password_mismatched(self, admin_client, mock_db):
+        mock_db.get_user_by_username.return_value = {
+            "id": 1,
+            "username": "alice",
+            "role": UserRole.REGULAR.value,
+            "is_active": True,
+            "first_name": None,
+            "last_name": None,
+            "email": None,
+            "phone": None,
+            "sms_notifications_enabled": False,
+            "api_key_hash": None,
+            "password_hash": "hashed",
+        }
+        response = admin_client.post(
+            "/admin/change_password/alice",
+            data={"new_password": "pass1", "confirm_password": "pass2"},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert not mock_db.update_user_password_by_admin.called

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -3,6 +3,7 @@ Integration tests for Flask HTTP routes (app.py).
 
 Uses the test client fixtures from conftest.py; no real database or hardware.
 """
+import secrets
 import subprocess
 from unittest.mock import MagicMock, patch
 
@@ -217,7 +218,6 @@ class TestGenerateApiKey:
         assert "/login" in response.headers["Location"]
 
     def test_authenticated_generates_key_and_redirects(self, auth_client, mock_db):
-        import secrets
         mock_db.generate_api_key.return_value = secrets.token_hex(32)
         response = auth_client.post("/generate_api_key", follow_redirects=False)
         assert response.status_code == 302
@@ -383,7 +383,12 @@ class TestAdminRoutes:
         mock_db.update_user_password_by_admin.assert_called_once_with("alice", "newpass")
 
     def test_change_password_mismatched(self, admin_client, mock_db):
-        mock_db.get_user_by_username.return_value = {
+        # admin_client sets get_user_by_username.return_value to the admin user.
+        # We keep that for Flask-Login auth but also need it to return alice's
+        # data when the route calls get_user_by_username('alice') to render the
+        # form on validation error.  Use side_effect to route by argument.
+        admin_user_data = mock_db.get_user_by_username.return_value
+        alice_user_data = {
             "id": 1,
             "username": "alice",
             "role": UserRole.REGULAR.value,
@@ -396,10 +401,21 @@ class TestAdminRoutes:
             "api_key_hash": None,
             "password_hash": "hashed",
         }
+
+        def get_user_by_username(username):
+            if username == "admin":
+                return admin_user_data
+            if username == "alice":
+                return alice_user_data
+            return None
+
+        mock_db.get_user_by_username.side_effect = get_user_by_username
+
         response = admin_client.post(
             "/admin/change_password/alice",
             data={"new_password": "pass1", "confirm_password": "pass2"},
             follow_redirects=True,
         )
         assert response.status_code == 200
+        assert b"do not match" in response.data.lower()
         assert not mock_db.update_user_password_by_admin.called

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -9,6 +9,7 @@ import hashlib
 import secrets
 from unittest.mock import MagicMock, patch
 
+import pymysql
 import pytest
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -226,8 +227,6 @@ class TestCreateUser:
         assert stored_role == UserRole.ADMIN.value
 
     def test_duplicate_username_returns_false(self):
-        import pymysql
-
         db = _make_db()
         conn = MagicMock()
         conn.__enter__ = MagicMock(return_value=conn)

--- a/tests/test_database_manager.py
+++ b/tests/test_database_manager.py
@@ -1,0 +1,465 @@
+"""
+Unit tests for DatabaseManager (database.py).
+
+All tests use a mock database connection so no real MySQL instance is needed.
+Each test creates a fresh DatabaseManager via __new__ (skipping __init__)
+and injects a mock connection via patch.object.
+"""
+import hashlib
+import secrets
+from unittest.mock import MagicMock, patch
+
+import pytest
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from database import DatabaseManager
+from user_roles import UserRole
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_db() -> DatabaseManager:
+    """Create a DatabaseManager instance bypassing __init__ (no real DB)."""
+    return DatabaseManager.__new__(DatabaseManager)
+
+
+def _make_mock_connection(fetchone=None, fetchall=None, rowcount=1):
+    """Build a mock connection/cursor stack.
+
+    Returns (mock_connection, mock_cursor) so tests can inspect calls.
+    """
+    cursor = MagicMock()
+    cursor.fetchone.return_value = fetchone
+    cursor.fetchall.return_value = fetchall if fetchall is not None else []
+    cursor.rowcount = rowcount
+
+    conn = MagicMock()
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    return conn, cursor
+
+
+# ---------------------------------------------------------------------------
+# generate_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateApiKey:
+    def test_returns_64_char_hex_string(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            key = db.generate_api_key("alice")
+        assert key is not None
+        assert len(key) == 64
+        int(key, 16)  # raises ValueError if not valid hex
+
+    def test_stores_sha256_hash_in_db(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            key = db.generate_api_key("alice")
+        expected_hash = hashlib.sha256(key.encode()).hexdigest()
+        call_params = cursor.execute.call_args[0][1]
+        assert call_params[0] == expected_hash
+
+    def test_username_passed_to_update(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            db.generate_api_key("bob")
+        call_params = cursor.execute.call_args[0][1]
+        assert call_params[1] == "bob"
+
+    def test_returns_none_when_user_not_found(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=0)
+        with patch.object(db, "get_connection", return_value=conn):
+            key = db.generate_api_key("nonexistent")
+        assert key is None
+
+    def test_returns_none_on_db_exception(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB error")):
+            key = db.generate_api_key("alice")
+        assert key is None
+
+    def test_each_call_generates_unique_key(self):
+        db = _make_db()
+        keys = set()
+        for _ in range(10):
+            conn, _ = _make_mock_connection(rowcount=1)
+            with patch.object(db, "get_connection", return_value=conn):
+                keys.add(db.generate_api_key("alice"))
+        assert len(keys) == 10
+
+
+# ---------------------------------------------------------------------------
+# get_user_by_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserByApiKey:
+    def test_returns_user_for_valid_key(self):
+        db = _make_db()
+        user_row = {"id": 1, "username": "alice", "role": "regular", "is_active": True}
+        conn, cursor = _make_mock_connection(fetchone=user_row)
+        with patch.object(db, "get_connection", return_value=conn):
+            result = db.get_user_by_api_key("somekey")
+        assert result == user_row
+
+    def test_queries_with_sha256_hash(self):
+        db = _make_db()
+        test_key = secrets.token_hex(32)
+        conn, cursor = _make_mock_connection(fetchone=None)
+        with patch.object(db, "get_connection", return_value=conn):
+            db.get_user_by_api_key(test_key)
+        expected_hash = hashlib.sha256(test_key.encode()).hexdigest()
+        call_params = cursor.execute.call_args[0][1]
+        assert call_params[0] == expected_hash
+
+    def test_returns_none_for_invalid_key(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(fetchone=None)
+        with patch.object(db, "get_connection", return_value=conn):
+            result = db.get_user_by_api_key("bad_key")
+        assert result is None
+
+    def test_returns_none_on_db_exception(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB error")):
+            result = db.get_user_by_api_key("somekey")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_user_by_username
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserByUsername:
+    def test_returns_user_dict(self):
+        db = _make_db()
+        row = {"id": 1, "username": "alice", "role": "regular", "is_active": True}
+        conn, _ = _make_mock_connection(fetchone=row)
+        with patch.object(db, "get_connection", return_value=conn):
+            result = db.get_user_by_username("alice")
+        assert result == row
+
+    def test_returns_none_when_not_found(self):
+        db = _make_db()
+        conn, _ = _make_mock_connection(fetchone=None)
+        with patch.object(db, "get_connection", return_value=conn):
+            result = db.get_user_by_username("ghost")
+        assert result is None
+
+    def test_returns_none_on_exception(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB error")):
+            result = db.get_user_by_username("alice")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# verify_password
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyPassword:
+    def test_correct_password_returns_true(self):
+        db = _make_db()
+        hashed = generate_password_hash("secret")
+        user_row = {"username": "alice", "password_hash": hashed, "is_active": True}
+        with patch.object(db, "get_user_by_username", return_value=user_row):
+            assert db.verify_password("alice", "secret") is True
+
+    def test_wrong_password_returns_false(self):
+        db = _make_db()
+        hashed = generate_password_hash("secret")
+        user_row = {"username": "alice", "password_hash": hashed, "is_active": True}
+        with patch.object(db, "get_user_by_username", return_value=user_row):
+            assert db.verify_password("alice", "wrong") is False
+
+    def test_unknown_user_returns_false(self):
+        db = _make_db()
+        with patch.object(db, "get_user_by_username", return_value=None):
+            assert db.verify_password("ghost", "anything") is False
+
+
+# ---------------------------------------------------------------------------
+# create_user
+# ---------------------------------------------------------------------------
+
+
+class TestCreateUser:
+    def test_creates_user_with_hashed_password(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            result = db.create_user("alice", "password123")
+        assert result is True
+        # Verify password is NOT stored as plain text
+        stored_hash = cursor.execute.call_args[0][1][1]
+        assert stored_hash != "password123"
+        assert check_password_hash(stored_hash, "password123")
+
+    def test_default_role_is_regular(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            db.create_user("alice", "password123")
+        stored_role = cursor.execute.call_args[0][1][2]
+        assert stored_role == UserRole.REGULAR.value
+
+    def test_explicit_admin_role_stored(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            db.create_user("boss", "password123", role=UserRole.ADMIN.value)
+        stored_role = cursor.execute.call_args[0][1][2]
+        assert stored_role == UserRole.ADMIN.value
+
+    def test_duplicate_username_returns_false(self):
+        import pymysql
+
+        db = _make_db()
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        cursor = MagicMock()
+        cursor.execute.side_effect = pymysql.IntegrityError("Duplicate entry")
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        with patch.object(db, "get_connection", return_value=conn):
+            result = db.create_user("alice", "password")
+        assert result is False
+
+    def test_db_exception_returns_false(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB down")):
+            result = db.create_user("alice", "password")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# update_password
+# ---------------------------------------------------------------------------
+
+
+class TestUpdatePassword:
+    def test_successful_update_returns_true(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.update_password("alice", "newpass") is True
+
+    def test_stores_hashed_password(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            db.update_password("alice", "newpass")
+        stored = cursor.execute.call_args[0][1][0]
+        assert stored != "newpass"
+        assert check_password_hash(stored, "newpass")
+
+    def test_user_not_found_returns_false(self):
+        db = _make_db()
+        conn, _ = _make_mock_connection(rowcount=0)
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.update_password("ghost", "newpass") is False
+
+    def test_db_exception_returns_false(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB down")):
+            assert db.update_password("alice", "newpass") is False
+
+
+# ---------------------------------------------------------------------------
+# update_user_profile
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateUserProfile:
+    def test_successful_update_returns_true(self):
+        db = _make_db()
+        conn, _ = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            result = db.update_user_profile(
+                "alice", "Alice", "Smith", "alice@example.com", "555-1234", True
+            )
+        assert result is True
+
+    def test_all_fields_passed_to_cursor(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            db.update_user_profile("alice", "Alice", "Smith", "a@b.com", "555", False)
+        params = cursor.execute.call_args[0][1]
+        assert params == ("Alice", "Smith", "a@b.com", "555", False, "alice")
+
+    def test_sms_enabled_stored_correctly(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            db.update_user_profile("alice", None, None, None, None, True)
+        params = cursor.execute.call_args[0][1]
+        assert params[4] is True  # sms_notifications_enabled
+
+    def test_user_not_found_returns_false(self):
+        db = _make_db()
+        conn, _ = _make_mock_connection(rowcount=0)
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.update_user_profile("ghost") is False
+
+    def test_db_exception_returns_false(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB down")):
+            assert db.update_user_profile("alice") is False
+
+
+# ---------------------------------------------------------------------------
+# deactivate_user
+# ---------------------------------------------------------------------------
+
+
+class TestDeactivateUser:
+    def test_successful_deactivation_returns_true(self):
+        db = _make_db()
+        conn, _ = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.deactivate_user("alice") is True
+
+    def test_user_not_found_returns_false(self):
+        db = _make_db()
+        conn, _ = _make_mock_connection(rowcount=0)
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.deactivate_user("ghost") is False
+
+    def test_db_exception_returns_false(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB down")):
+            assert db.deactivate_user("alice") is False
+
+
+# ---------------------------------------------------------------------------
+# get_all_users
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllUsers:
+    def test_returns_list_of_users(self):
+        db = _make_db()
+        rows = [{"id": 1, "username": "alice"}, {"id": 2, "username": "bob"}]
+        conn, _ = _make_mock_connection(fetchall=rows)
+        with patch.object(db, "get_connection", return_value=conn):
+            result = db.get_all_users()
+        assert result == rows
+
+    def test_returns_empty_list_when_no_users(self):
+        db = _make_db()
+        conn, _ = _make_mock_connection(fetchall=[])
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.get_all_users() == []
+
+    def test_returns_empty_list_on_exception(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB down")):
+            assert db.get_all_users() == []
+
+
+# ---------------------------------------------------------------------------
+# delete_user
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUser:
+    def _make_delete_connection(self, admin_count, user_role, rowcount=1):
+        """Build a cursor that returns admin count first, then user role."""
+        cursor = MagicMock()
+        cursor.fetchone.side_effect = [
+            {"count": admin_count},
+            {"role": user_role} if user_role else None,
+        ]
+        cursor.rowcount = rowcount
+
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor)
+        conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return conn, cursor
+
+    def test_deletes_regular_user_successfully(self):
+        db = _make_db()
+        conn, _ = self._make_delete_connection(
+            admin_count=1, user_role=UserRole.REGULAR.value, rowcount=1
+        )
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.delete_user("alice") is True
+
+    def test_blocks_deletion_of_last_admin(self):
+        db = _make_db()
+        conn, _ = self._make_delete_connection(
+            admin_count=1, user_role=UserRole.ADMIN.value, rowcount=1
+        )
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.delete_user("admin") is False
+
+    def test_allows_deletion_of_admin_when_another_admin_exists(self):
+        db = _make_db()
+        conn, _ = self._make_delete_connection(
+            admin_count=2, user_role=UserRole.ADMIN.value, rowcount=1
+        )
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.delete_user("admin2") is True
+
+    def test_returns_false_when_user_not_found(self):
+        db = _make_db()
+        conn, _ = self._make_delete_connection(
+            admin_count=1, user_role=UserRole.REGULAR.value, rowcount=0
+        )
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.delete_user("ghost") is False
+
+    def test_returns_false_on_exception(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB down")):
+            assert db.delete_user("alice") is False
+
+
+# ---------------------------------------------------------------------------
+# update_user_password_by_admin
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateUserPasswordByAdmin:
+    def test_successful_update_returns_true(self):
+        db = _make_db()
+        conn, _ = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.update_user_password_by_admin("alice", "newpass") is True
+
+    def test_stores_hashed_password(self):
+        db = _make_db()
+        conn, cursor = _make_mock_connection(rowcount=1)
+        with patch.object(db, "get_connection", return_value=conn):
+            db.update_user_password_by_admin("alice", "adminset")
+        stored = cursor.execute.call_args[0][1][0]
+        assert check_password_hash(stored, "adminset")
+
+    def test_user_not_found_returns_false(self):
+        db = _make_db()
+        conn, _ = _make_mock_connection(rowcount=0)
+        with patch.object(db, "get_connection", return_value=conn):
+            assert db.update_user_password_by_admin("ghost", "newpass") is False
+
+    def test_db_exception_returns_false(self):
+        db = _make_db()
+        with patch.object(db, "get_connection", side_effect=Exception("DB down")):
+            assert db.update_user_password_by_admin("alice", "newpass") is False

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,116 @@
+"""
+Tests for the custom route decorators (app.py):
+
+  - admin_required  – blocks non-admin authenticated users; passes admins through
+  - api_key_required – validates X-API-Key header against the database
+"""
+import secrets
+from unittest.mock import patch
+
+import pytest
+from user_roles import UserRole
+
+
+# ---------------------------------------------------------------------------
+# admin_required
+# ---------------------------------------------------------------------------
+
+
+class TestAdminRequired:
+    """admin_required redirects regular users and allows admins."""
+
+    def test_unauthenticated_redirected_to_login(self, client):
+        """Unauthenticated request is redirected to /login by Flask-Login."""
+        response = client.get("/admin", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/login" in response.headers["Location"]
+
+    def test_regular_user_cannot_access_admin(self, auth_client):
+        """Authenticated regular user is redirected away from /admin."""
+        response = auth_client.get("/admin", follow_redirects=False)
+        # Should redirect (admin_required sends them to home, login_required to login)
+        assert response.status_code == 302
+
+    def test_admin_user_can_access_admin_page(self, admin_client, mock_db):
+        """Authenticated admin user gets a 200 from /admin."""
+        mock_db.get_all_users.return_value = []
+        response = admin_client.get("/admin", follow_redirects=False)
+        assert response.status_code == 200
+
+    def test_regular_user_cannot_access_create_user(self, auth_client):
+        response = auth_client.get("/admin/create_user", follow_redirects=False)
+        assert response.status_code == 302
+
+    def test_admin_can_access_create_user(self, admin_client):
+        response = admin_client.get("/admin/create_user", follow_redirects=False)
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# api_key_required
+# ---------------------------------------------------------------------------
+
+
+class TestApiKeyRequired:
+    """api_key_required validates API keys via X-API-Key header."""
+
+    def test_missing_header_returns_401(self, client):
+        response = client.get("/api/door_status")
+        assert response.status_code == 401
+
+    def test_missing_header_returns_error_json(self, client):
+        response = client.get("/api/door_status")
+        data = response.get_json()
+        assert data is not None
+        assert "error" in data
+        assert data["error"] == "Invalid API key"
+
+    def test_invalid_key_returns_401(self, client, mock_db):
+        mock_db.get_user_by_api_key.return_value = None
+        response = client.get("/api/door_status", headers={"X-API-Key": "bad_key"})
+        assert response.status_code == 401
+
+    def test_invalid_key_returns_error_json(self, client, mock_db):
+        mock_db.get_user_by_api_key.return_value = None
+        response = client.get("/api/door_status", headers={"X-API-Key": "bad_key"})
+        data = response.get_json()
+        assert data["error"] == "Invalid API key"
+
+    def test_valid_key_returns_200(self, client, mock_db):
+        mock_db.get_user_by_api_key.return_value = {
+            "id": 1,
+            "username": "apiuser",
+            "role": UserRole.REGULAR.value,
+            "is_active": True,
+        }
+        import subprocess
+        from unittest.mock import MagicMock
+        mock_proc = MagicMock()
+        mock_proc.stdout = "Door Closed\n"
+        mock_proc.stderr = ""
+        with patch("subprocess.run", return_value=mock_proc):
+            response = client.get(
+                "/api/door_status",
+                headers={"X-API-Key": secrets.token_hex(32)},
+            )
+        assert response.status_code == 200
+
+    def test_valid_key_response_contains_status(self, client, mock_db):
+        mock_db.get_user_by_api_key.return_value = {
+            "id": 1,
+            "username": "apiuser",
+            "role": UserRole.REGULAR.value,
+            "is_active": True,
+        }
+        from unittest.mock import MagicMock
+        mock_proc = MagicMock()
+        mock_proc.stdout = "Door Opened\n"
+        mock_proc.stderr = ""
+        with patch("subprocess.run", return_value=mock_proc):
+            response = client.get(
+                "/api/door_status",
+                headers={"X-API-Key": secrets.token_hex(32)},
+            )
+        data = response.get_json()
+        assert "status" in data
+        assert data["status"] == "open"

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -5,7 +5,8 @@ Tests for the custom route decorators (app.py):
   - api_key_required – validates X-API-Key header against the database
 """
 import secrets
-from unittest.mock import patch
+import subprocess
+from unittest.mock import MagicMock, patch
 
 import pytest
 from user_roles import UserRole
@@ -83,8 +84,6 @@ class TestApiKeyRequired:
             "role": UserRole.REGULAR.value,
             "is_active": True,
         }
-        import subprocess
-        from unittest.mock import MagicMock
         mock_proc = MagicMock()
         mock_proc.stdout = "Door Closed\n"
         mock_proc.stderr = ""
@@ -102,7 +101,6 @@ class TestApiKeyRequired:
             "role": UserRole.REGULAR.value,
             "is_active": True,
         }
-        from unittest.mock import MagicMock
         mock_proc = MagicMock()
         mock_proc.stdout = "Door Opened\n"
         mock_proc.stderr = ""

--- a/tests/test_door_status.py
+++ b/tests/test_door_status.py
@@ -1,0 +1,97 @@
+"""
+Tests for the _get_door_status helper function (app.py).
+
+The function calls doorStatus.py as a subprocess and parses its stdout.
+All subprocess calls are mocked so no real hardware or scripts are executed.
+"""
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import _get_door_status
+
+
+def _make_completed_process(stdout="", stderr="", returncode=0):
+    result = MagicMock(spec=subprocess.CompletedProcess)
+    result.stdout = stdout
+    result.stderr = stderr
+    result.returncode = returncode
+    return result
+
+
+class TestDoorStatusParsing:
+    """Status string is parsed correctly from subprocess stdout."""
+
+    def test_door_closed_detected(self):
+        mock_result = _make_completed_process(stdout="Door Closed\n")
+        with patch("subprocess.run", return_value=mock_result):
+            data = _get_door_status()
+        assert data["success"] is True
+        assert data["status"] == "closed"
+
+    def test_door_opened_detected(self):
+        mock_result = _make_completed_process(stdout="Door Opened\n")
+        with patch("subprocess.run", return_value=mock_result):
+            data = _get_door_status()
+        assert data["success"] is True
+        assert data["status"] == "open"
+
+    def test_unknown_status_for_unrecognised_output(self):
+        mock_result = _make_completed_process(stdout="Automation HAT not found.\n")
+        with patch("subprocess.run", return_value=mock_result):
+            data = _get_door_status()
+        assert data["success"] is True
+        assert data["status"] == "unknown"
+
+    def test_empty_output_gives_unknown(self):
+        mock_result = _make_completed_process(stdout="")
+        with patch("subprocess.run", return_value=mock_result):
+            data = _get_door_status()
+        assert data["status"] == "unknown"
+
+    def test_raw_output_returned(self):
+        mock_result = _make_completed_process(stdout="Door Closed\n")
+        with patch("subprocess.run", return_value=mock_result):
+            data = _get_door_status()
+        assert data["raw_output"] == "Door Closed"
+
+    def test_stderr_returned_when_present(self):
+        mock_result = _make_completed_process(stdout="", stderr="some warning")
+        with patch("subprocess.run", return_value=mock_result):
+            data = _get_door_status()
+        assert data["error"] == "some warning"
+
+    def test_error_is_none_when_stderr_empty(self):
+        mock_result = _make_completed_process(stdout="Door Closed\n", stderr="")
+        with patch("subprocess.run", return_value=mock_result):
+            data = _get_door_status()
+        assert data["error"] is None
+
+
+class TestDoorStatusErrorHandling:
+    """Failures are reported as success=False with an error message."""
+
+    def test_timeout_returns_failure(self):
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("python", 10)):
+            data = _get_door_status()
+        assert data["success"] is False
+        assert "timed out" in data["error"].lower()
+
+    def test_generic_exception_returns_failure(self):
+        with patch("subprocess.run", side_effect=OSError("script not found")):
+            data = _get_door_status()
+        assert data["success"] is False
+        assert data["error"] is not None
+
+    def test_success_key_present_on_normal_result(self):
+        mock_result = _make_completed_process(stdout="Door Opened\n")
+        with patch("subprocess.run", return_value=mock_result):
+            data = _get_door_status()
+        assert "success" in data
+
+    def test_status_key_present_on_normal_result(self):
+        mock_result = _make_completed_process(stdout="Door Closed\n")
+        with patch("subprocess.run", return_value=mock_result):
+            data = _get_door_status()
+        assert "status" in data

--- a/tests/test_user_model.py
+++ b/tests/test_user_model.py
@@ -1,0 +1,73 @@
+"""
+Tests for the User model class (defined in app.py).
+
+The User class wraps Flask-Login's UserMixin and adds role-based helpers.
+"""
+import pytest
+from user_roles import UserRole
+
+
+# Import User from the already-patched app module (DB mock is in conftest.py).
+from app import User
+
+
+class TestUserCreation:
+    """User instances are created with correct attributes."""
+
+    def test_id_is_username(self):
+        user = User("alice", user_id=1, role=UserRole.REGULAR.value)
+        assert user.id == "alice"
+
+    def test_user_id_stored(self):
+        user = User("alice", user_id=42, role=UserRole.REGULAR.value)
+        assert user.user_id == 42
+
+    def test_role_stored(self):
+        user = User("alice", user_id=1, role=UserRole.ADMIN.value)
+        assert user.role == UserRole.ADMIN.value
+
+    def test_default_role_is_regular_when_none_passed(self):
+        user = User("alice", user_id=1, role=None)
+        assert user.role == UserRole.REGULAR.value
+
+    def test_default_role_when_role_omitted(self):
+        user = User("alice", user_id=1)
+        assert user.role == UserRole.REGULAR.value
+
+
+class TestUserIsAdmin:
+    """is_admin() correctly reflects the user's role."""
+
+    def test_admin_user_is_admin(self):
+        user = User("admin", user_id=1, role=UserRole.ADMIN.value)
+        assert user.is_admin() is True
+
+    def test_regular_user_is_not_admin(self):
+        user = User("regular", user_id=2, role=UserRole.REGULAR.value)
+        assert user.is_admin() is False
+
+    def test_default_user_is_not_admin(self):
+        user = User("regular")
+        assert user.is_admin() is False
+
+
+class TestUserMixinIntegration:
+    """User inherits Flask-Login's UserMixin correctly."""
+
+    def test_is_authenticated_true(self):
+        """UserMixin provides is_authenticated = True by default."""
+        user = User("alice", user_id=1)
+        assert user.is_authenticated is True
+
+    def test_is_active_true(self):
+        user = User("alice", user_id=1)
+        assert user.is_active is True
+
+    def test_is_anonymous_false(self):
+        user = User("alice", user_id=1)
+        assert user.is_anonymous is False
+
+    def test_get_id_returns_username(self):
+        """get_id() is used by Flask-Login; it should return the user's id."""
+        user = User("alice", user_id=1)
+        assert user.get_id() == "alice"

--- a/tests/test_user_roles.py
+++ b/tests/test_user_roles.py
@@ -1,0 +1,59 @@
+"""
+Tests for the UserRole enum (user_roles.py).
+
+Covers role values, validation, and default role logic.
+"""
+import pytest
+from user_roles import UserRole
+
+
+class TestUserRoleValues:
+    """Enum values match the expected strings stored in the database."""
+
+    def test_admin_value(self):
+        assert UserRole.ADMIN.value == "admin"
+
+    def test_regular_value(self):
+        assert UserRole.REGULAR.value == "regular"
+
+    def test_enum_has_exactly_two_roles(self):
+        assert len(list(UserRole)) == 2
+
+
+class TestUserRoleIsValid:
+    """UserRole.is_valid() correctly accepts and rejects role strings."""
+
+    def test_admin_string_is_valid(self):
+        assert UserRole.is_valid("admin") is True
+
+    def test_regular_string_is_valid(self):
+        assert UserRole.is_valid("regular") is True
+
+    def test_unknown_role_is_invalid(self):
+        assert UserRole.is_valid("superuser") is False
+
+    def test_empty_string_is_invalid(self):
+        assert UserRole.is_valid("") is False
+
+    def test_none_is_invalid(self):
+        # is_valid compares against enum values (strings); None should not match
+        assert UserRole.is_valid(None) is False
+
+    def test_uppercase_admin_is_invalid(self):
+        """Role validation is case-sensitive – DB stores lowercase."""
+        assert UserRole.is_valid("Admin") is False
+        assert UserRole.is_valid("ADMIN") is False
+
+    def test_uppercase_regular_is_invalid(self):
+        assert UserRole.is_valid("Regular") is False
+        assert UserRole.is_valid("REGULAR") is False
+
+
+class TestUserRoleGetDefault:
+    """get_default() always returns the REGULAR role."""
+
+    def test_get_default_returns_regular(self):
+        assert UserRole.get_default() == UserRole.REGULAR
+
+    def test_get_default_value_is_regular_string(self):
+        assert UserRole.get_default().value == "regular"

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "apscheduler" },
-    { name = "automationhat" },
+    { name = "automationhat", marker = "platform_machine == 'aarch64'" },
     { name = "flask" },
     { name = "flask-login" },
     { name = "flask-socketio" },
@@ -17,16 +17,28 @@ dependencies = [
     { name = "werkzeug" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "apscheduler", specifier = "==3.10.4" },
-    { name = "automationhat", specifier = "==1.0.0" },
+    { name = "automationhat", marker = "platform_machine == 'aarch64'", specifier = "==1.0.0" },
     { name = "flask", specifier = "==3.0.0" },
     { name = "flask-login", specifier = "==0.6.3" },
     { name = "flask-socketio", specifier = "==5.3.6" },
     { name = "pymysql", specifier = "==1.1.0" },
     { name = "python-dotenv", specifier = "==1.0.0" },
     { name = "werkzeug", specifier = "==3.0.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
 ]
 
 [[package]]
@@ -111,6 +123,45 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/56/95b7e30fa389756cb56630faa728da46a27b8c6eb46f9d557c68fff12b65/coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91", size = 827239, upload-time = "2026-02-09T12:59:03.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/11/a9cf762bb83386467737d32187756a42094927150c3e107df4cb078e8590/coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601", size = 219522, upload-time = "2026-02-09T12:58:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/28/56e6d892b7b052236d67c95f1936b6a7cf7c3e2634bf27610b8cbd7f9c60/coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689", size = 219855, upload-time = "2026-02-09T12:58:10.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/69/233459ee9eb0c0d10fcc2fe425a029b3fa5ce0f040c966ebce851d030c70/coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c", size = 250887, upload-time = "2026-02-09T12:58:12.503Z" },
+    { url = "https://files.pythonhosted.org/packages/06/90/2cdab0974b9b5bbc1623f7876b73603aecac11b8d95b85b5b86b32de5eab/coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129", size = 253396, upload-time = "2026-02-09T12:58:14.615Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/15/ea4da0f85bf7d7b27635039e649e99deb8173fe551096ea15017f7053537/coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552", size = 254745, upload-time = "2026-02-09T12:58:16.162Z" },
+    { url = "https://files.pythonhosted.org/packages/99/11/bb356e86920c655ca4d61daee4e2bbc7258f0a37de0be32d233b561134ff/coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a", size = 257055, upload-time = "2026-02-09T12:58:17.892Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0f/9ae1f8cb17029e09da06ca4e28c9e1d5c1c0a511c7074592e37e0836c915/coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356", size = 250911, upload-time = "2026-02-09T12:58:19.495Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3a/adfb68558fa815cbc29747b553bc833d2150228f251b127f1ce97e48547c/coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71", size = 252754, upload-time = "2026-02-09T12:58:21.064Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b1/540d0c27c4e748bd3cd0bd001076ee416eda993c2bae47a73b7cc9357931/coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5", size = 250720, upload-time = "2026-02-09T12:58:22.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/95/383609462b3ffb1fe133014a7c84fc0dd01ed55ac6140fa1093b5af7ebb1/coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98", size = 254994, upload-time = "2026-02-09T12:58:24.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ba/1761138e86c81680bfc3c49579d66312865457f9fe405b033184e5793cb3/coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5", size = 250531, upload-time = "2026-02-09T12:58:26.271Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8e/05900df797a9c11837ab59c4d6fe94094e029582aab75c3309a93e6fb4e3/coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0", size = 252189, upload-time = "2026-02-09T12:58:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bd/29c9f2db9ea4ed2738b8a9508c35626eb205d51af4ab7bf56a21a2e49926/coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb", size = 222258, upload-time = "2026-02-09T12:58:29.441Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/1f8e723f6829977410efeb88f73673d794075091c8c7c18848d273dc9d73/coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505", size = 223073, upload-time = "2026-02-09T12:58:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5b/84100025be913b44e082ea32abcf1afbf4e872f5120b7a1cab1d331b1e13/coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2", size = 221638, upload-time = "2026-02-09T12:58:32.599Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/e4/c884a405d6ead1370433dad1e3720216b4f9fd8ef5b64bfd984a2a60a11a/coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056", size = 220246, upload-time = "2026-02-09T12:58:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5c/4d7ed8b23b233b0fffbc9dfec53c232be2e695468523242ea9fd30f97ad2/coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc", size = 220514, upload-time = "2026-02-09T12:58:35.704Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6f/3284d4203fd2f28edd73034968398cd2d4cb04ab192abc8cff007ea35679/coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9", size = 261877, upload-time = "2026-02-09T12:58:37.864Z" },
+    { url = "https://files.pythonhosted.org/packages/09/aa/b672a647bbe1556a85337dc95bfd40d146e9965ead9cc2fe81bde1e5cbce/coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf", size = 264004, upload-time = "2026-02-09T12:58:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a1/aa384dbe9181f98bba87dd23dda436f0c6cf2e148aecbb4e50fc51c1a656/coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55", size = 266408, upload-time = "2026-02-09T12:58:41.852Z" },
+    { url = "https://files.pythonhosted.org/packages/53/5e/5150bf17b4019bc600799f376bb9606941e55bd5a775dc1e096b6ffea952/coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72", size = 267544, upload-time = "2026-02-09T12:58:44.093Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/f1de5c675987a4a7a672250d2c5c9d73d289dbf13410f00ed7181d8017dd/coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a", size = 260980, upload-time = "2026-02-09T12:58:45.721Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/e3/fe758d01850aa172419a6743fe76ba8b92c29d181d4f676ffe2dae2ba631/coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6", size = 263871, upload-time = "2026-02-09T12:58:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/76/b829869d464115e22499541def9796b25312b8cf235d3bb00b39f1675395/coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3", size = 261472, upload-time = "2026-02-09T12:58:48.995Z" },
+    { url = "https://files.pythonhosted.org/packages/14/9e/caedb1679e73e2f6ad240173f55218488bfe043e38da577c4ec977489915/coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750", size = 265210, upload-time = "2026-02-09T12:58:51.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/10/0dd02cb009b16ede425b49ec344aba13a6ae1dc39600840ea6abcb085ac4/coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39", size = 260319, upload-time = "2026-02-09T12:58:53.081Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8e/234d2c927af27c6d7a5ffad5bd2cf31634c46a477b4c7adfbfa66baf7ebb/coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0", size = 262638, upload-time = "2026-02-09T12:58:55.258Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/64/e5547c8ff6964e5965c35a480855911b61509cce544f4d442caa759a0702/coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea", size = 223040, upload-time = "2026-02-09T12:58:56.936Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[[package]]
 name = "flask"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -159,9 +210,7 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0c/dc/5a6bd309345bd9cfa7e098174ab7e65367e408539b6c1998e4f267c673cd/gpiod-2.4.0.tar.gz", hash = "sha256:9243a1a59d084ec749d1df4a1e2f238ffb9d94515b0d9f5335460175143c3aa1", size = 58180, upload-time = "2025-10-24T14:58:08.584Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/23/08/cb17d4c4876954ffc3560e8fbe71528d46deda0f1d6e2c1a65824a6073e4/gpiod-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75c9ac86275c3cb14779f0fb6e671067ae0d9c20e41b6f18c9487db6897fdd86", size = 104748, upload-time = "2025-10-24T14:57:58.921Z" },
-    { url = "https://files.pythonhosted.org/packages/87/2d/793d6b9f5f126d16bd12ba933fde50b2b2614ace70b8f328291369754acd/gpiod-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6eb53c3052b5012bb87e67359254851dad8a2e3134839d871520fdfee3897a0f", size = 104431, upload-time = "2025-10-24T14:57:59.981Z" },
     { url = "https://files.pythonhosted.org/packages/b5/a5/72876d06e151bb337862f7635765d21cab2a2c2452cc36d670ffb7cdd6a2/gpiod-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ea9e6ff91fc42e456cee1ba9bf955d9b787a29955f645a7bdacbccd243d7b191", size = 103006, upload-time = "2025-10-24T14:58:00.955Z" },
-    { url = "https://files.pythonhosted.org/packages/be/62/385fc9a61e5ab67cf4533fe14431600a29a54f565784170f8d90731d7947/gpiod-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d5b321d34f475eb7f8359be2c4181c5098012fb34c92c948f17744704bd66a77", size = 102910, upload-time = "2025-10-24T14:58:02.066Z" },
 ]
 
 [[package]]
@@ -195,6 +244,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/9f/017fbfac4f1c69be128b59f432a16d5d9559794c1975c926bd549596bbfe/i2cdevice-1.0.0.tar.gz", hash = "sha256:a9a5d1666a11b6733d16c73f148fc85cba767dd1b976e5bcc56ad970986c96c4", size = 17023, upload-time = "2023-10-30T11:59:46.688Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/0c/38c1b44e9233378fad579ce89040d934d12c53ed8536982ad26a6a3bab7f/i2cdevice-1.0.0-py3-none-any.whl", hash = "sha256:595cfa3815aab4d8a4bbe1cbd4a4e1271d56cf7c1de367eab6a94dd80566f0c1", size = 10801, upload-time = "2023-10-30T11:59:43.562Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -254,27 +312,43 @@ version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/fd/0005efbd0af48e55eb3c7208af93f2862d4b1a56cd78e84309a2d959208d/numpy-2.4.2.tar.gz", hash = "sha256:659a6107e31a83c4e33f763942275fd278b21d095094044eb35569e86a21ddae", size = 20723651, upload-time = "2026-01-31T23:13:10.135Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/88/b7df6050bf18fdcfb7046286c6535cabbdd2064a3440fca3f069d319c16e/numpy-2.4.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:444be170853f1f9d528428eceb55f12918e4fda5d8805480f36a002f1415e09b", size = 16663092, upload-time = "2026-01-31T23:12:04.521Z" },
     { url = "https://files.pythonhosted.org/packages/25/7a/1fee4329abc705a469a4afe6e69b1ef7e915117747886327104a8493a955/numpy-2.4.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d1240d50adff70c2a88217698ca844723068533f3f5c5fa6ee2e3220e3bdb000", size = 14698770, upload-time = "2026-01-31T23:12:06.96Z" },
     { url = "https://files.pythonhosted.org/packages/fb/0b/f9e49ba6c923678ad5bc38181c08ac5e53b7a5754dbca8e581aa1a56b1ff/numpy-2.4.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:7cdde6de52fb6664b00b056341265441192d1291c130e99183ec0d4b110ff8b1", size = 5208562, upload-time = "2026-01-31T23:12:09.632Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/12/d7de8f6f53f9bb76997e5e4c069eda2051e3fe134e9181671c4391677bb2/numpy-2.4.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:cda077c2e5b780200b6b3e09d0b42205a3d1c68f30c6dceb90401c13bff8fe74", size = 6543710, upload-time = "2026-01-31T23:12:11.969Z" },
     { url = "https://files.pythonhosted.org/packages/09/63/c66418c2e0268a31a4cf8a8b512685748200f8e8e8ec6c507ce14e773529/numpy-2.4.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d30291931c915b2ab5717c2974bb95ee891a1cf22ebc16a8006bd59cd210d40a", size = 15677205, upload-time = "2026-01-31T23:12:14.33Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/6c/7f237821c9642fb2a04d2f1e88b4295677144ca93285fd76eff3bcba858d/numpy-2.4.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bba37bc29d4d85761deed3954a1bc62be7cf462b9510b51d367b769a8c8df325", size = 16611738, upload-time = "2026-01-31T23:12:16.525Z" },
     { url = "https://files.pythonhosted.org/packages/c2/a7/39c4cdda9f019b609b5c473899d87abff092fc908cfe4d1ecb2fcff453b0/numpy-2.4.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b2f0073ed0868db1dcd86e052d37279eef185b9c8db5bf61f30f46adac63c909", size = 17028888, upload-time = "2026-01-31T23:12:19.306Z" },
-    { url = "https://files.pythonhosted.org/packages/da/b3/e84bb64bdfea967cc10950d71090ec2d84b49bc691df0025dddb7c26e8e3/numpy-2.4.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7f54844851cdb630ceb623dcec4db3240d1ac13d4990532446761baede94996a", size = 18339556, upload-time = "2026-01-31T23:12:21.816Z" },
-    { url = "https://files.pythonhosted.org/packages/88/f5/954a291bc1192a27081706862ac62bb5920fbecfbaa302f64682aa90beed/numpy-2.4.2-cp314-cp314-win32.whl", hash = "sha256:12e26134a0331d8dbd9351620f037ec470b7c75929cb8a1537f6bfe411152a1a", size = 6006899, upload-time = "2026-01-31T23:12:24.14Z" },
-    { url = "https://files.pythonhosted.org/packages/05/cb/eff72a91b2efdd1bc98b3b8759f6a1654aa87612fc86e3d87d6fe4f948c4/numpy-2.4.2-cp314-cp314-win_amd64.whl", hash = "sha256:068cdb2d0d644cdb45670810894f6a0600797a69c05f1ac478e8d31670b8ee75", size = 12443072, upload-time = "2026-01-31T23:12:26.33Z" },
     { url = "https://files.pythonhosted.org/packages/37/75/62726948db36a56428fce4ba80a115716dc4fad6a3a4352487f8bb950966/numpy-2.4.2-cp314-cp314-win_arm64.whl", hash = "sha256:6ed0be1ee58eef41231a5c943d7d1375f093142702d5723ca2eb07db9b934b05", size = 10494886, upload-time = "2026-01-31T23:12:28.488Z" },
     { url = "https://files.pythonhosted.org/packages/36/2f/ee93744f1e0661dc267e4b21940870cabfae187c092e1433b77b09b50ac4/numpy-2.4.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:98f16a80e917003a12c0580f97b5f875853ebc33e2eaa4bccfc8201ac6869308", size = 14818567, upload-time = "2026-01-31T23:12:30.709Z" },
     { url = "https://files.pythonhosted.org/packages/a7/24/6535212add7d76ff938d8bdc654f53f88d35cddedf807a599e180dcb8e66/numpy-2.4.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:20abd069b9cda45874498b245c8015b18ace6de8546bf50dfa8cea1696ed06ef", size = 5328372, upload-time = "2026-01-31T23:12:32.962Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/9d/c48f0a035725f925634bf6b8994253b43f2047f6778a54147d7e213bc5a7/numpy-2.4.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:e98c97502435b53741540a5717a6749ac2ada901056c7db951d33e11c885cc7d", size = 6649306, upload-time = "2026-01-31T23:12:34.797Z" },
     { url = "https://files.pythonhosted.org/packages/81/05/7c73a9574cd4a53a25907bad38b59ac83919c0ddc8234ec157f344d57d9a/numpy-2.4.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da6cad4e82cb893db4b69105c604d805e0c3ce11501a55b5e9f9083b47d2ffe8", size = 15722394, upload-time = "2026-01-31T23:12:36.565Z" },
-    { url = "https://files.pythonhosted.org/packages/35/fa/4de10089f21fc7d18442c4a767ab156b25c2a6eaf187c0db6d9ecdaeb43f/numpy-2.4.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e4424677ce4b47fe73c8b5556d876571f7c6945d264201180db2dc34f676ab5", size = 16653343, upload-time = "2026-01-31T23:12:39.188Z" },
     { url = "https://files.pythonhosted.org/packages/b8/f9/d33e4ffc857f3763a57aa85650f2e82486832d7492280ac21ba9efda80da/numpy-2.4.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2b8f157c8a6f20eb657e240f8985cc135598b2b46985c5bccbde7616dc9c6b1e", size = 17078045, upload-time = "2026-01-31T23:12:42.041Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/b8/54bdb43b6225badbea6389fa038c4ef868c44f5890f95dd530a218706da3/numpy-2.4.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5daf6f3914a733336dab21a05cdec343144600e964d2fcdabaac0c0269874b2a", size = 18380024, upload-time = "2026-01-31T23:12:44.331Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/55/6e1a61ded7af8df04016d81b5b02daa59f2ea9252ee0397cb9f631efe9e5/numpy-2.4.2-cp314-cp314t-win32.whl", hash = "sha256:8c50dd1fc8826f5b26a5ee4d77ca55d88a895f4e4819c7ecc2a9f5905047a443", size = 6153937, upload-time = "2026-01-31T23:12:47.229Z" },
-    { url = "https://files.pythonhosted.org/packages/45/aa/fa6118d1ed6d776b0983f3ceac9b1a5558e80df9365b1c3aa6d42bf9eee4/numpy-2.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fcf92bee92742edd401ba41135185866f7026c502617f422eb432cfeca4fe236", size = 12631844, upload-time = "2026-01-31T23:12:48.997Z" },
     { url = "https://files.pythonhosted.org/packages/32/0a/2ec5deea6dcd158f254a7b372fb09cfba5719419c8d66343bab35237b3fb/numpy-2.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:1f92f53998a17265194018d1cc321b2e96e900ca52d54c7c77837b71b9465181", size = 10565379, upload-time = "2026-01-31T23:12:51.345Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
 ]
 
 [[package]]
@@ -284,6 +358,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/9d/ee68dee1c8821c839bb31e6e5f40e61035a5278f7c1307dde758f0c90452/PyMySQL-1.1.0.tar.gz", hash = "sha256:4f13a7df8bf36a51e81dd9f3605fede45a4878fe02f9236349fd82a3f0612f96", size = 47240, upload-time = "2023-06-26T05:34:02.058Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/20467e39523d0cfc2b6227902d3687a16364307260c75e6a1cb4422b0c62/PyMySQL-1.1.0-py3-none-any.whl", hash = "sha256:8969ec6d763c856f7073c4c64662882675702efcb114b4bcbb955aea3a069fa7", size = 44768, upload-time = "2023-06-26T05:33:59.951Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **128 pytest unit/integration tests** covering all core modules with no real database or hardware required
- **GitHub Actions CI workflow** that runs the full test suite on Python 3.11 and 3.12 for every push and PR targeting `main`
- **`pyproject.toml` updates**: dev dependency group (`pytest`, `pytest-cov`) and `automationhat` restricted to `aarch64` so CI runners don't fail on a Raspberry Pi-only package

## Test coverage

| File | What's tested |
|------|---------------|
| `tests/test_user_roles.py` | `UserRole` enum values, `is_valid()`, `get_default()` |
| `tests/test_user_model.py` | `User` class construction, `is_admin()`, `UserMixin` contract |
| `tests/test_database_manager.py` | All 11 `DatabaseManager` methods with mocked DB connections |
| `tests/test_door_status.py` | `_get_door_status()` output parsing, timeout, and error paths |
| `tests/test_decorators.py` | `admin_required` and `api_key_required` decorators |
| `tests/test_app_routes.py` | Every Flask route: login, logout, profile, admin CRUD, door control, API key generation, public pages |

## CI workflow

`.github/workflows/tests.yml` runs on `push` and `pull_request` to `main`:
- Installs deps via `uv sync --group dev` (skips `automationhat` on non-Pi)
- Runs `pytest tests/ -v --tb=short`
- Uploads `.pytest_cache` as an artifact on failure for easy debugging

## Test plan

- [x] All 128 tests pass locally (`uv run pytest tests/ -v`)
- [x] CI workflow YAML is syntactically valid
- [x] No real MySQL connection or Raspberry Pi hardware needed
- [x] Branch created from fresh `main` (`8ad56f8`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)